### PR TITLE
Release 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["hitori", "hitori-macros"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Artur Helmanau <m30bit@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ For example, using [regex] one can rewrite `a+` as `a*a` and it would still  mat
 sequence of `a`s longer than zero. With [hitori], however, `a*` would consume
 all the `a`s, and the expression won't match. 
 
-Most of the times, expression can be altered to mitigate [hitori] limitations. 
-
 Step-by step pattern matching also leads to diminished performance when matching
 large texts and an expression contains repetitions of frequent characters.
 

--- a/hitori/Cargo.toml
+++ b/hitori/Cargo.toml
@@ -26,7 +26,7 @@ find-hitori = ["hitori-macros?/proc-macro-crate"]
 examples = []
 
 [dependencies]
-hitori-macros = { version = "=0.2.0", path = "../hitori-macros", optional = true }
+hitori-macros = { version = "=0.2.1", path = "../hitori-macros", optional = true }
 
 [dev-dependencies]
 regex = "1.7.3"

--- a/hitori/src/examples/putting_everything_together.rs
+++ b/hitori/src/examples/putting_everything_together.rs
@@ -1,4 +1,4 @@
-//! More complex examples of using [hitori]
+//! More complex examples
 //!
 //! ### Email
 //!
@@ -9,7 +9,7 @@
 //! let matched = hitori::string::starts_with(Email, s).unwrap();
 //! assert_eq!(&s[matched.capture.user.unwrap()], "user");
 //! assert_eq!(&s[matched.capture.domain_with_extension.unwrap()], "example.com");
-//! //assert_eq!(&s[matched.capture.domain_extension.unwrap()], "com");
+//! assert_eq!(&s[matched.capture.domain_extension.unwrap()], "com");
 //! ```
 //! *equivalent to `[\w\.+-]+@[\w\.-]+\.[\w\.-]+` in [regex] syntax*
 //!

--- a/hitori/src/expr.rs
+++ b/hitori/src/expr.rs
@@ -1,7 +1,7 @@
 use core::ops::Range;
 
 /// A single [`ExprMut`] match
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Clone)]
 pub struct Match<Idx, C, I> {
     /// Index [`Range`] of matched subsequence of characters
     pub range: Range<Idx>,


### PR DESCRIPTION
- typos
- remove some of `Match` derives